### PR TITLE
Flat structure

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -1,13 +1,15 @@
+var nanocontent = require('../')
 var css = require('sheetify')
-var hypha = require('hypha')
 var choo = require('choo')
-css('./src/design/index.js')
 
-var site = hypha.readSiteSync('./content', {
+var site = nanocontent.readSiteSync('./content', {
   parent: '/content'
 })
 
 var app = choo()
+
+// design
+css('./src/design/index.js')
 
 // content and routes
 app.use(require('./src/stores/content')(site))

--- a/example/package.json
+++ b/example/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hypha-example",
+  "name": "nanocontent-example",
   "version": "1.0.0",
   "description": "nice",
   "main": "index.js",

--- a/lib/readFile.js
+++ b/lib/readFile.js
@@ -1,6 +1,6 @@
 var assert = require('assert')
 
-var utilFile = require('../utils/file')
+var utilPage = require('../utils/page')
 var readPage = require('./readPage')
 
 module.exports = readFile
@@ -10,9 +10,8 @@ async function readFile (pathFile, opts) {
   assert.equal(typeof opts, 'object', 'arg2: opts must be type object')
   assert.equal(typeof opts.fs, 'object', 'arg2: opts.fs must be type object')
 
-  if (!utilFile.isFile(pathFile)) {
-    return readPage(pathFile, opts)
-  } else {
-    return false
-  }
+  // pages
+  if (utilPage.isPage(pathFile)) return readPage(pathFile, opts)
+
+  return false
 }

--- a/lib/readFile.js
+++ b/lib/readFile.js
@@ -1,7 +1,13 @@
+var { promisify } = require('util')
 var assert = require('assert')
+var smarkt = require('smarkt')
+var xtend = require('xtend')
+var path = require('path')
 
+var utilFile = require('../utils/file')
 var utilPage = require('../utils/page')
 var readPage = require('./readPage')
+var defaults = require('./defaults')
 
 module.exports = readFile
 
@@ -13,5 +19,39 @@ async function readFile (pathFile, opts) {
   // pages
   if (utilPage.isPage(pathFile)) return readPage(pathFile, opts)
 
-  return false
+  var fs = opts.fs
+  var parse = typeof opts.parse === 'function' ? opts.parse : smarkt.parse
+  var fileIndex = opts.file || defaults.file
+  var fileExtname = path.extname(fileIndex).toLowerCase()
+  var filetypes = opts.filetypes || defaults.filetypes
+  var pathRoot = opts.pathRoot || ''
+  var encoding = opts.encoding || defaults.encoding
+  var fileParsed = utilFile.getFileMeta({
+    pathFile: pathFile,
+    pathRoot: pathRoot,
+    filetypes: filetypes,
+    pathSource: opts.source,
+    pathSiteParent: opts.parent
+  })
+
+  // skip text files
+  if (fileExtname === fileParsed.extension) return false
+
+  // async readFile
+  var readFile = isAsync(fs.readFile)
+    ? fs.readFile
+    : promisify(fs.readFile)
+
+  try {
+    var pathMeta = pathFile + fileExtname
+    var text = await readFile(pathMeta, encoding)
+    return xtend(parse(text), fileParsed)
+  } catch (err) {
+    if (fileParsed.filename) return Promise.resolve(fileParsed)
+    else return Promise.resolve(false)
+  }
+}
+
+function isAsync (fn) {
+  return fn.constructor.name === 'AsyncFunction'
 }

--- a/lib/readFileSync.js
+++ b/lib/readFileSync.js
@@ -1,7 +1,7 @@
 var assert = require('assert')
 
 var readPageSync = require('./readPageSync')
-var utilFile = require('../utils/file')
+var utilPage = require('../utils/page')
 
 module.exports = readFileSync
 
@@ -10,9 +10,8 @@ function readFileSync (pathFile, opts) {
   assert.equal(typeof opts, 'object', 'arg2: opts must be type object')
   assert.equal(typeof opts.fs, 'object', 'arg2: opts.fs must be type object')
 
-  if (!utilFile.isFile(pathFile)) {
-    return readPageSync(pathFile, opts)
-  } else {
-    return false
-  }
+  // pages
+  if (utilPage.isPage(pathFile)) return readPageSync(pathFile, opts)
+
+  return false
 }

--- a/lib/readFileSync.js
+++ b/lib/readFileSync.js
@@ -1,7 +1,12 @@
 var assert = require('assert')
+var smarkt = require('smarkt')
+var xtend = require('xtend')
+var path = require('path')
 
 var readPageSync = require('./readPageSync')
+var utilFile = require('../utils/file')
 var utilPage = require('../utils/page')
+var defaults = require('./defaults')
 
 module.exports = readFileSync
 
@@ -10,8 +15,32 @@ function readFileSync (pathFile, opts) {
   assert.equal(typeof opts, 'object', 'arg2: opts must be type object')
   assert.equal(typeof opts.fs, 'object', 'arg2: opts.fs must be type object')
 
-  // pages
+  // page
   if (utilPage.isPage(pathFile)) return readPageSync(pathFile, opts)
 
-  return false
+  var fs = opts.fs
+  var parse = typeof opts.parse === 'function' ? opts.parse : smarkt.parse
+  var fileIndex = opts.file || defaults.file
+  var fileExtname = path.extname(fileIndex).toLowerCase()
+  var filetypes = opts.filetypes || defaults.filetypes
+  var pathRoot = opts.pathRoot || ''
+  var encoding = opts.encoding || defaults.encoding
+  var fileParsed = utilFile.getFileMeta({
+    pathFile: pathFile,
+    pathRoot: pathRoot,
+    filetypes: filetypes,
+    pathSiteParent: opts.parent
+  })
+
+  // skip text files
+  if (fileExtname === fileParsed.extension) return false
+
+  try {
+    var pathMeta = pathFile + fileExtname
+    var text = fs.readFileSync(pathMeta, encoding)
+    return xtend(parse(text), fileParsed)
+  } catch (err) {
+    if (fileParsed.filename) return fileParsed
+    else return false
+  }
 }

--- a/lib/readPage.js
+++ b/lib/readPage.js
@@ -18,92 +18,23 @@ async function readPage (pathPage, opts) {
   var fs = opts.fs.url ? opts.fs : pify(opts.fs) // web api or node
   var parse = typeof opts.parse === 'function' ? opts.parse : smarkt.parse
   var fileIndex = opts.file || defaults.file
-  var fileExtname = path.extname(fileIndex)
-  var filetypes = opts.filetypes || defaults.filetypes
   var pathRoot = opts.pathRoot || ''
   var pathUrl = utilFile.formatUrl(pathPage, pathRoot, opts.parent)
   var encoding = opts.encoding || defaults.encoding
   var content = await getContent()
-  var childrenInput = await getChildren()
-  var children = childrenInput
-    .filter(file => utilFile.filterFile(file, fileIndex))
-    .reduce(utilFile.sortChildren, { files: [], pages: [] })
-  var files = await getFiles(children.files)
-  var pages = getPages(children.pages)
 
   return xtend(content, {
     name: path.basename(pathPage),
     path: utilFile.formatUrl(pathPage, pathRoot),
-    url: pathUrl,
-    files: files,
-    pages: pages
+    url: pathUrl
   })
-
-  async function getChildren () {
-    try {
-      return await fs.readdir(pathPage)
-    } catch (err) {
-      return []
-    }
-  }
 
   async function getContent () {
     try {
-      var content
-      content = await fs.readFile(slash(path.join(pathPage, fileIndex)), encoding)
-      content = parse(content)
-      return content
+      var content = await fs.readFile(slash(path.join(pathPage, fileIndex)), encoding)
+      return parse(content)
     } catch (err) {
       return ''
     }
-  }
-
-  async function getFiles (files) {
-    var result = { }
-    await Promise.all(files.map(read))
-    return result
-
-    async function read (pathFile) {
-      var fileParsed = utilFile.getFileMeta({
-        pathFile: pathFile,
-        pathRoot: pathRoot,
-        filetypes: filetypes,
-        pathParent: pathPage,
-        pathSource: opts.source,
-        pathSiteParent: opts.parent
-      })
-
-      try {
-        var fileMeta = pathFile + fileExtname
-        var pathMeta = path.join(pathPage, fileMeta)
-        var text = await fs.readFile(pathMeta, encoding)
-        // set
-        result[fileParsed.filename] = xtend(parse(text), fileParsed)
-        files.splice(files.indexOf(fileMeta), 1)
-        // cleanup
-        delete result[fileMeta]
-        return text
-      } catch (err) {
-        if (fileParsed.filename) {
-          result[fileParsed.filename] = fileParsed
-        }
-        return Promise.resolve()
-      }
-    }
-  }
-
-  function getPages (pages) {
-    return pages.reduce(function (result, pathSubpage) {
-      var fileParsed = utilFile.getFileMeta({
-        pathRoot: pathRoot,
-        pathFile: pathSubpage,
-        filetypes: filetypes,
-        pathParent: pathPage,
-        pathSiteParent: opts.parent
-      })
-
-      if (fileParsed.name) result[fileParsed.name] = fileParsed
-      return result
-    }, {})
   }
 }

--- a/lib/readPageSync.js
+++ b/lib/readPageSync.js
@@ -17,86 +17,23 @@ function readPageSync (pathPage, opts) {
   var fs = opts.fs
   var parse = typeof opts.parse === 'function' ? opts.parse : smarkt.parse
   var fileIndex = opts.file || defaults.file
-  var fileExtname = path.extname(fileIndex)
-  var filetypes = opts.filetypes || defaults.filetypes
   var pathRoot = opts.pathRoot || ''
   var pathUrl = utilFile.formatUrl(pathPage, pathRoot, opts.parent)
   var encoding = opts.encoding || defaults.encoding
   var content = getContent()
-  var children = getChildren()
-    .filter(file => utilFile.filterFile(file, fileIndex))
-    .reduce(utilFile.sortChildren, { files: [ ], pages: [ ] })
-  var files = getFiles(children.files)
-  var pages = getPages(children.pages)
 
   return xtend(content, {
     name: path.basename(pathPage),
     path: utilFile.formatUrl(pathPage, pathRoot),
-    url: pathUrl,
-    files: files,
-    pages: pages
+    url: pathUrl
   })
-
-  function getChildren () {
-    try {
-      return fs.readdirSync(pathPage)
-    } catch (err) {
-      return [ ]
-    }
-  }
 
   function getContent () {
     try {
-      var content
-      content = fs.readFileSync(slash(path.join(pathPage, fileIndex)), encoding)
-      content = parse(content)
-      return content
+      var content = fs.readFileSync(slash(path.join(pathPage, fileIndex)), encoding)
+      return parse(content)
     } catch (err) {
       return ''
     }
-  }
-
-  function getFiles (files) {
-    return files.reduce(function (result, pathFile) {
-      var fileParsed = utilFile.getFileMeta({
-        pathFile: pathFile,
-        pathRoot: pathRoot,
-        filetypes: filetypes,
-        pathParent: pathPage,
-        pathSiteParent: opts.parent
-      })
-
-      try {
-        var fileMeta = pathFile + fileExtname
-        var text = fs.readFileSync(slash(path.join(pathPage, fileMeta)), encoding)
-        // set
-        result[fileParsed.filename] = xtend(parse(text), fileParsed)
-        files.splice(files.indexOf(fileMeta), 1)
-        // cleanup
-        delete result[fileMeta]
-      } catch (err) {
-        if (fileParsed.filename) {
-          result[fileParsed.filename] = fileParsed
-        }
-      }
-
-      return result
-    }, { })
-  }
-
-  function getPages (pages) {
-    return pages.reduce(function (result, pathSubpage) {
-      var fileParsed = utilFile.getFileMeta({
-        pathRoot: pathRoot,
-        pathFile: pathSubpage,
-        filetypes: filetypes,
-        pathParent: pathPage,
-        pathSource: opts.source,
-        pathSiteParent: opts.parent
-      })
-
-      if (fileParsed.name) result[fileParsed.name] = fileParsed
-      return result
-    }, { })
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ var site = nanocontent.readSiteSync('./content')
 
 Each directory becomes a path containing a sub-object of the content in your text file. 
 
-```
+```js
 {
   '/': { },
   '/about': { },

--- a/test.js
+++ b/test.js
@@ -1,38 +1,38 @@
 var test = require('ava')
-var hypha = require('.')
+var nanocontent = require('.')
 
 test('readPageSync works', function (t) {
-  var page = hypha.readPageSync('example/content/about')
+  var page = nanocontent.readPageSync('example/content/about')
   t.is(page.title, 'About')
   t.is(page.view, 'custom')
 })
 
 test('readPage works', async function (t) {
-  var page = await hypha.readPage('example/content/about')
+  var page = await nanocontent.readPage('example/content/about')
   t.is(page.title, 'About')
   t.is(page.view, 'custom')
 })
 
 test('readPageSync and readPage outputs are the same', async function (t) {
-  var syncPage = hypha.readPageSync('example/content/about')
-  var asyncPage = await hypha.readPage('example/content/about')
+  var syncPage = nanocontent.readPageSync('example/content/about')
+  var asyncPage = await nanocontent.readPage('example/content/about')
   t.deepEqual(syncPage, asyncPage)
 })
 
 test('readSiteSync works', function (t) {
-  var site = hypha.readSiteSync('example/content')
+  var site = nanocontent.readSiteSync('example/content')
   t.is(site['/example/content'].title, 'Example')
   t.is(site['/example/content/about'].title, 'About')
 })
 
 test('readSiteSync and readSite outputs are the same', async function (t) {
-  var syncSite = hypha.readSiteSync('example/content')
-  var asyncSite = await hypha.readSite('example/content')
+  var syncSite = nanocontent.readSiteSync('example/content')
+  var asyncSite = await nanocontent.readSite('example/content')
   t.deepEqual(syncSite, asyncSite)
 })
 
 test('readSiteSync and readSite outputs are the same with parent option', async function (t) {
-  var syncSite = hypha.readSiteSync('example/content', { parent: true })
-  var asyncSite = await hypha.readSite('example/content', { parent: true })
+  var syncSite = nanocontent.readSiteSync('example/content', { parent: true })
+  var asyncSite = await nanocontent.readSite('example/content', { parent: true })
   t.deepEqual(syncSite, asyncSite)
 })

--- a/transform.js
+++ b/transform.js
@@ -2,7 +2,7 @@ var staticModule = require('static-module')
 var through = require('through2')
 var path = require('path')
 
-var hypha = require('.')
+var nanocontent = require('.')
 
 module.exports = transform
 
@@ -15,13 +15,13 @@ function transform (filename) {
   }
 
   var sm = staticModule({
-    hypha: {
+    nanocontent: {
       readPageSync: function (pathPage, opts) {
         opts = opts || { }
         opts.pathRoot = opts.pathRoot || vars.__dirname
 
         var pathDir = path.isAbsolute(pathPage) ? pathPage : path.join(vars.__dirname, pathPage)
-        var pageSync = hypha.readPageSync(pathDir, opts)
+        var pageSync = nanocontent.readPageSync(pathDir, opts)
 
         var stream = through()
         stream.push(JSON.stringify(pageSync, { }, 2))
@@ -37,7 +37,7 @@ function transform (filename) {
         }
 
         var pathDir = path.isAbsolute(pathSite) ? pathSite : path.join(vars.__dirname, pathSite)
-        var siteSync = hypha.readSiteSync(pathDir, opts)
+        var siteSync = nanocontent.readSiteSync(pathDir, opts)
 
         var stream = through()
         stream.push(JSON.stringify(siteSync, { }, 2))

--- a/utils/file.js
+++ b/utils/file.js
@@ -56,15 +56,14 @@ function isFile (pathFile) {
 function getFileMeta (opts) {
   assert.equal(typeof opts, 'object', 'arg1 opts must be type object')
   assert.equal(typeof opts.pathFile, 'string', 'arg1 opts.pathFile must be type string')
-  assert.equal(typeof opts.pathParent, 'string', 'arg1 opts.pathParent must be type string')
   assert.equal(typeof opts.pathRoot, 'string', 'arg1 opts.pathRoot must be type string')
   assert.equal(typeof opts.filetypes, 'object', 'arg1 opts.filetypes must be type string')
 
   var output = { }
   var ext = path.extname(opts.pathFile)
   output.name = path.basename(opts.pathFile, ext)
-  output.path = formatUrl(path.join('/', opts.pathParent, '/', opts.pathFile), opts.pathRoot)
-  output.url = formatUrl(path.join('/', opts.pathParent, '/', opts.pathFile), opts.pathRoot, opts.pathSiteParent)
+  output.path = formatUrl(opts.pathFile, opts.pathRoot)
+  output.url = formatUrl(opts.pathFile, opts.pathRoot, opts.pathSiteParent)
   output.source = opts.pathSource ? (opts.pathSource + output.path) : output.path
 
   if (ext) {

--- a/utils/file.js
+++ b/utils/file.js
@@ -1,6 +1,6 @@
 var objectKeys = require('object-keys')
-var assert = require('assert')
 var slash = require('normalize-path')
+var assert = require('assert')
 var path = require('path')
 
 module.exports = {
@@ -49,16 +49,16 @@ function getFileType (extension, filetypes) {
 }
 
 function isFile (pathFile) {
-  assert.equal(typeof pathFile, 'string', 'enoki: arg1 pathFile must be type string')
+  assert.equal(typeof pathFile, 'string', 'arg1 pathFile must be type string')
   return path.extname(pathFile) !== ''
 }
 
 function getFileMeta (opts) {
-  assert.equal(typeof opts, 'object', 'enoki: arg1 opts must be type object')
-  assert.equal(typeof opts.pathFile, 'string', 'enoki: arg1 opts.pathFile must be type string')
-  assert.equal(typeof opts.pathParent, 'string', 'enoki: arg1 opts.pathParent must be type string')
-  assert.equal(typeof opts.pathRoot, 'string', 'enoki: arg1 opts.pathRoot must be type string')
-  assert.equal(typeof opts.filetypes, 'object', 'enoki: arg1 opts.filetypes must be type string')
+  assert.equal(typeof opts, 'object', 'arg1 opts must be type object')
+  assert.equal(typeof opts.pathFile, 'string', 'arg1 opts.pathFile must be type string')
+  assert.equal(typeof opts.pathParent, 'string', 'arg1 opts.pathParent must be type string')
+  assert.equal(typeof opts.pathRoot, 'string', 'arg1 opts.pathRoot must be type string')
+  assert.equal(typeof opts.filetypes, 'object', 'arg1 opts.filetypes must be type string')
 
   var output = { }
   var ext = path.extname(opts.pathFile)

--- a/utils/page.js
+++ b/utils/page.js
@@ -1,0 +1,11 @@
+var assert = require('assert')
+var path = require('path')
+
+module.exports = {
+  isPage: isPage
+}
+
+function isPage (pathPage) {
+  assert.equal(typeof pathPage, 'string', 'arg1 pathPage must be type string')
+  return path.extname(pathPage) === ''
+}


### PR DESCRIPTION
Finalizes the migration to generating truly flat content state.

1. Removes `pages` and `files` objects.
2. Follows content state schema.
3. Fixes some funny async stuff.

Best used with [`nanopage`](https://github.com/jondashkyle/nanocontent/) which makes traversing content state paths, collecting children pages/files, and all sorts of other stuff super simple.